### PR TITLE
fix: jekyll-whiteglass theme 문제인지 파악하기 위해 theme을 변경하여 테스트하다

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,8 @@ source "https://rubygems.org"
 # gem "jekyll", "~> 4.3.2"
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minima", "~> 2.5"
-gem "jekyll-theme-primer", "~> 0.6"
+# gem "jekyll-whiteglass"
+# gem "jekyll-theme-primer", "~> 0.6"
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
 # gem "github-pages", group: :jekyll_plugins
@@ -18,9 +19,6 @@ gem "jekyll-theme-primer", "~> 0.6"
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"
 end
-
-# my jekyll theme
-  gem "jekyll-whiteglass"
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
 # and associated library.


### PR DESCRIPTION
github-pages 가 지원하는 `jekyll theme` 은 한정되어있다고 한다.
theme 문제인지 테스트하기 위해 지원하는 테마로 바꿔본다.

<img width="500" alt="스크린샷 2023-05-07 오후 4 42 37" src="https://user-images.githubusercontent.com/80025242/236664666-9f5c0d48-2973-4859-a919-33db2222b845.png">