### PR TITLE
fix: github token 위치를 travis CI로 옮기고 theme을 다시 jekyll-whiteglass로 원복시키다

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,6 @@ script:
     kill -9 "$(cat jekyll.pid)" && \
     rm -f jekyll.pid && \
     rm -rf _tmp_site
-env:
-  global:
-    - GITHUB_TOKEN=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
 branches:
   only:
     - main

--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,8 @@ source "https://rubygems.org"
 # Happy Jekylling!
 # gem "jekyll", "~> 4.3.2"
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
-gem "minima", "~> 2.5"
-# gem "jekyll-whiteglass"
+# gem "minima", "~> 2.5"
+gem "jekyll-whiteglass"
 # gem "jekyll-theme-primer", "~> 0.6"
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.


### PR DESCRIPTION
travis CI 에 이 repository 한정 환경 변수를 등록하다.

<img width="800" alt="스크린샷 2023-05-07 오후 5 48 43" src="https://user-images.githubusercontent.com/80025242/236667572-664b244d-2d5b-4136-a01f-4f499f1b2d37.png">
